### PR TITLE
Add Fire OS detection and fix missing UNK key

### DIFF
--- a/device_detector/parser/operating_system.py
+++ b/device_detector/parser/operating_system.py
@@ -30,6 +30,7 @@ OPERATING_SYSTEMS = {
     'DEB': 'Debian',
     'DFB': 'DragonFly',
     'FED': 'Fedora',
+    'FIR': 'Fire OS',
     'FOS': 'Firefox OS',
     'BSD': 'FreeBSD',
     'GNT': 'Gentoo',
@@ -91,6 +92,7 @@ OPERATING_SYSTEMS = {
     'POS': 'palmOS',
     'WOS': 'webOS',
     'WIO': 'Windows IoT',
+    'UNK': 'Unknown',
 }
 
 # flip Abbrev / OS for fast membership testing
@@ -98,7 +100,7 @@ OS_TO_ABBREV = {os.lower(): abbrev for abbrev, os in OPERATING_SYSTEMS.items()}
 
 OS_FAMILIES = {
     'Android': [
-        'AND', 'CYN', 'REM', 'RZD', 'MLD', 'MCD', 'YNS',
+        'AND', 'CYN', 'REM', 'RZD', 'MLD', 'MCD', 'YNS', 'FIR',
     ],
     'AmigaOS': ['AMG', 'MOR'],
     'Apple TV': ['ATV'],
@@ -191,9 +193,9 @@ class OS(Parser):
             self.ua_data.update({
                 # Overwrite name for capitalization.
                 # insensitive regex match preserves original casing
-                'name': self.OPERATING_SYSTEMS[abbreviation],
+                'name': self.OPERATING_SYSTEMS.get(abbreviation),
                 'short_name': abbreviation,
-                'family': self.FAMILY_FROM_OS[abbreviation],
+                'family': self.FAMILY_FROM_OS.get(abbreviation),
                 'platform': self.platform(),
             })
 


### PR DESCRIPTION
Hi,

I had this error : 
```
  File "lib/python3.6/site-packages/device_detector/device_detector.py", line 103, in parse
    self.parse_os()
  File "lib/python3.6/site-packages/device_detector/device_detector.py", line 150, in parse_os
    self.os = OS(self.user_agent).parse()
  File "lib/python3.6/site-packages/device_detector/parser/parser.py", line 142, in parse
    self.set_details()
  File "lib/python3.6/site-packages/device_detector/parser/operating_system.py", line 194, in set_details
    'name': self.OPERATING_SYSTEMS[abbreviation],
KeyError: 'UNK'
```

With this user agent : Fire OS/5.3.6.2 stagefright/1.2 (Linux;Android 5.1.1)

So I checked and noticed that :
- Fire OS was not in your operating_system.py file
- You use the UNK key when your script don't find the OS name, but UNK was not in your OPERATING_SYSTEMS dict.

Thanks