### PR TITLE
add Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 dist: xenial
 language: python
 python:
-  - "3.4"
-  - "3.5"
   - "3.6"
   - "3.7"  
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+dist: xenial
+language: python
+python:
+  - "3.4"
+  - "3.5"
+  - "3.6"
+  - "3.7"  
+install:
+  - pip install -r requirements.txt
+  - pip install -r optional-requirements.txt
+script:
+  - python -m unittest


### PR DESCRIPTION
It seems like there is a test in this repo, but it doesn't seem to be run as it is currently broken. (because of https://github.com/matomo-org/device-detector/pull/5971)

So it might be helpful to run the test automatically for all supported python versions.

That way one can also see that python 3.5 and 3.4 are currently broken as `blake2s` was only added in 3.6 so you might want to change this or drop support.

see https://travis-ci.com/Findus23/device_detector/builds/114634086 for the build results

