### PR TITLE
Fixed ZeroDivisionError when UA contains punctuation only

### DIFF
--- a/device_detector/parser/client/base.py
+++ b/device_detector/parser/client/base.py
@@ -171,6 +171,8 @@ class GenericClientParser(BaseClientParser):
         alphabetic characters are less than 50% of the string
         """
         app_no_punc = self.app_name_no_punc()
+        if not app_no_punc:
+            return True
 
         try:
             int(app_no_punc)


### PR DESCRIPTION
There's an edge case when `alphabetic_chars / len(app_no_punc) < threshold` fails with `ZeroDivisionError`. It's extremely rare in real-world data (as in "couple of dozens per hundreds of millions"-rare), but quite destructive nevertheless.
One of the inputs that cause this is `"%7C%7C%27"`, which decodes into `"||'"` and leads (after punctuation stripping) to `0/0` evaluation.  
  
Not sure if an empty string should result in `True` or `False` to be returned, but since `True` effectively forces the whole thing to be discarded (and such strings should definitely be discarded) it makes more sense to me.