### PR TITLE
Build a wheel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,5 +21,5 @@ clean-pyc: ## Remove Python file artifacts
 test: ## Run the tests
 	$(PYTHON) -m unittest
 
-sdist: clean ## Package new release
-	$(PYTHON) setup.py sdist
+packages: clean ## Package new release
+	$(PYTHON) -m build


### PR DESCRIPTION
Please publish wheels as well as source distributions.

This pull request updates the makefile to build both.  You may need to "python -m pip install build" first; just as (presumably) you must install twine before publishing the package.